### PR TITLE
✨ [FEATURE] Added Cron Format

### DIFF
--- a/samples/EasyCron.Sample/Jobs/ConsoleCronJob.cs
+++ b/samples/EasyCron.Sample/Jobs/ConsoleCronJob.cs
@@ -13,7 +13,7 @@ namespace EasyCron.Sample.Jobs
         private readonly ILogger<ConsoleCronJob> logger;
 
         public ConsoleCronJob(ICronConfiguration<ConsoleCronJob> cronConfiguration, ILogger<ConsoleCronJob> logger) 
-            : base(cronConfiguration.CronExpression,cronConfiguration.TimeZoneInfo)
+            : base(cronConfiguration.CronExpression,cronConfiguration.TimeZoneInfo, cronConfiguration.CronFormat)
         {
             this.logger = logger;
         }

--- a/samples/EasyCron.Sample/Startup.cs
+++ b/samples/EasyCron.Sample/Startup.cs
@@ -36,22 +36,22 @@ namespace EasyCron.Sample
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "EasyCron.Sample", Version = "v1" });
             });
 
-            //services.ApplyResulation<ConsoleCronJob>(options =>
-            //{
-            //    options.CronExpression = "*/10 * * * * *";
-            //    options.TimeZoneInfo = TimeZoneInfo.Local;
-            //    options.CronFormat = Cronos.CronFormat.IncludeSeconds;
-            //});
-            //services.ApplyResulation<MyJob>(options =>
-            //{
-            //    options.CronExpression = "* * * * *";
-            //    options.TimeZoneInfo = TimeZoneInfo.Local;
-            //    options.CronFormat = Cronos.CronFormat.Standard;
-            //});
+            services.ApplyResulation<ConsoleCronJob>(options =>
+            {
+                options.CronExpression = "*/10 * * * * *";
+                options.TimeZoneInfo = TimeZoneInfo.Local;
+                options.CronFormat = Cronos.CronFormat.IncludeSeconds;
+            });
+            services.ApplyResulation<MyJob>(options =>
+            {
+                options.CronExpression = "* * * * *";
+                options.TimeZoneInfo = TimeZoneInfo.Local;
+                options.CronFormat = Cronos.CronFormat.Standard;
+            });
 
 
-            services.InitializeCronServices();
-            services.AutoConfigurer();
+            //services.InitializeCronServices();
+            //services.AutoConfigurer();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/EasyCron.Sample/Startup.cs
+++ b/samples/EasyCron.Sample/Startup.cs
@@ -36,20 +36,22 @@ namespace EasyCron.Sample
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "EasyCron.Sample", Version = "v1" });
             });
 
-            services.ApplyResulation<ConsoleCronJob>(options =>
-            {
-                options.CronExpression = "* * * * *";
-                options.TimeZoneInfo = TimeZoneInfo.Local;
-            });
-            services.ApplyResulation<MyJob>(options =>
-            {
-                options.CronExpression = "* * * * *";
-                options.TimeZoneInfo = TimeZoneInfo.Local;
-            });
+            //services.ApplyResulation<ConsoleCronJob>(options =>
+            //{
+            //    options.CronExpression = "*/10 * * * * *";
+            //    options.TimeZoneInfo = TimeZoneInfo.Local;
+            //    options.CronFormat = Cronos.CronFormat.IncludeSeconds;
+            //});
+            //services.ApplyResulation<MyJob>(options =>
+            //{
+            //    options.CronExpression = "* * * * *";
+            //    options.TimeZoneInfo = TimeZoneInfo.Local;
+            //    options.CronFormat = Cronos.CronFormat.Standard;
+            //});
 
 
-            //services.InitializeCronServices();
-            //services.AutoConfigurer();
+            services.InitializeCronServices();
+            services.AutoConfigurer();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/EasyCron.Sample/appsettings.json
+++ b/samples/EasyCron.Sample/appsettings.json
@@ -9,12 +9,14 @@
   "AllowedHosts": "*",
   "CronJobs": {
     "ConsoleCronJob": {
-      "CronExpression": "* * * * *",
-      "TimeZoneInfo": "Local"
+      "CronExpression": "*/10 * * * * *",
+      "TimeZoneInfo": "Local",
+      "CronFormat": "IncludeSeconds"
     },
     "MyJob": {
       "CronExpression": "*/2 * * * *",
-      "TimeZoneInfo": "Local"
+      "TimeZoneInfo": "Local",
+      "CronFormat": "Standard"
     }
   }
 }

--- a/src/EasyCronJob.Abstractions/CronConfiguration.cs
+++ b/src/EasyCronJob.Abstractions/CronConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Cronos;
+using System;
 
 namespace EasyCronJob.Abstractions
 {
@@ -17,5 +18,11 @@ namespace EasyCronJob.Abstractions
         /// Represents any time zone in the world.
         /// </summary>
         public TimeZoneInfo TimeZoneInfo { get; set; }
+        
+        /// <summary>
+        /// Cron Format
+        /// Default <see cref="CronFormat.Standard"/>
+        /// </summary>
+        public CronFormat CronFormat { get; set; } = CronFormat.Standard;
     }
 }

--- a/src/EasyCronJob.Abstractions/CronJobService.cs
+++ b/src/EasyCronJob.Abstractions/CronJobService.cs
@@ -16,11 +16,13 @@ namespace EasyCronJob.Abstractions
     {
         private System.Timers.Timer timer;
         private readonly TimeZoneInfo timeZoneInfo;
+        private readonly CronFormat cronFormat;
         private readonly CronExpression cronExpression;
-        protected CronJobService(string cronExpression, TimeZoneInfo timeZoneInfo)
+        protected CronJobService(string cronExpression, TimeZoneInfo timeZoneInfo, CronFormat cronFormat = CronFormat.Standard)
         {
             this.timeZoneInfo = timeZoneInfo;
-            this.cronExpression = CronExpression.Parse(cronExpression);
+            this.cronFormat = cronFormat;
+            this.cronExpression = CronExpression.Parse(cronExpression, this.cronFormat);
         }
 
         protected virtual async Task ScheduleJob(CancellationToken cancellationToken)

--- a/src/EasyCronJob.Abstractions/EasyCronJob.Abstractions.csproj
+++ b/src/EasyCronJob.Abstractions/EasyCronJob.Abstractions.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net5.0</TargetFramework>
 		<Authors>furkandeveloper</Authors>
 		<Company>furkandeveloper</Company>
-		<Version>2.0.0</Version>
+		<Version>2.1.0</Version>
 		<Description>This library provides abstraction layer for EasyCronJob.Core library.</Description>
 		<PackageIcon>easyCronJob.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/furkandeveloper/EasyCronJob</PackageProjectUrl>

--- a/src/EasyCronJob.Abstractions/ICronConfiguration.cs
+++ b/src/EasyCronJob.Abstractions/ICronConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Cronos;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -23,5 +24,11 @@ namespace EasyCronJob.Abstractions
         /// TimeZone Information
         /// </summary>
         public TimeZoneInfo TimeZoneInfo { get; set; }
+
+        /// <summary>
+        /// Cron Format
+        /// Default <see cref="CronFormat.Standard"/>
+        /// </summary>
+        public CronFormat CronFormat { get; set; }
     }
 }

--- a/src/EasyCronJob.AutoConfigurer/EasyCronJob.AutoConfigurer.csproj
+++ b/src/EasyCronJob.AutoConfigurer/EasyCronJob.AutoConfigurer.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net5.0</TargetFramework>
 		<Authors>furkandeveloper</Authors>
 		<Company>furkandeveloper</Company>
-		<Version>2.0.0</Version>
+		<Version>2.1.0</Version>
 		<Description>This repository provides easy cron job to your application on IHostedService.</Description>
 		<PackageIcon>easyCronJob.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/furkandeveloper/EasyCronJob</PackageProjectUrl>

--- a/src/EasyCronJob.Core/EasyCronJob.Core.csproj
+++ b/src/EasyCronJob.Core/EasyCronJob.Core.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net5.0</TargetFramework>
 		<Authors>furkandeveloper</Authors>
 		<Company>furkandeveloper</Company>
-		<Version>2.0.0</Version>
+		<Version>2.1.0</Version>
 		<Description>This repository provides easy cron job to your application on IHostedService.</Description>
 		<PackageIcon>easyCronJob.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/furkandeveloper/EasyCronJob</PackageProjectUrl>


### PR DESCRIPTION
## Summary

This PR includes added cron format for cron services.

Cron jobs can sometimes be set in seconds.

Until now `EasyCronJob` used to support standard formats.

You can now use cron jobs in seconds.

For standard configuration;

Install `EasyCronJob.Core` from [Nuget](https://www.nuget.org/packages/EasyCronJob.Core/)

```csharp
services.ApplyResulation<ConsoleCronJob>(options =>
{
    options.CronExpression = "*/10 * * * * *";
    options.TimeZoneInfo = TimeZoneInfo.Local;
    options.CronFormat = Cronos.CronFormat.IncludeSeconds;
});
services.ApplyResulation<MyJob>(options =>
{
    options.CronExpression = "* * * * *";
    options.TimeZoneInfo = TimeZoneInfo.Local;
    options.CronFormat = Cronos.CronFormat.Standard;
});
```

For auto configuration;

Install `EasyCronJob.AutoConfigurer` from [Nuget](https://www.nuget.org/packages/EasyCronJob.AutoConfigurer/)

```json
"CronJobs": {
    "ConsoleCronJob": {
      "CronExpression": "*/10 * * * * *",
      "TimeZoneInfo": "Local",
      "CronFormat": "IncludeSeconds"
    },
    "MyJob": {
      "CronExpression": "*/2 * * * *",
      "TimeZoneInfo": "Local",
      "CronFormat": "Standard"
    }
  }
```

```csharp
services.InitializeCronServices();
services.AutoConfigurer();
```

***

**NOTE**
This PR was developed by community feature request.

See the issue for detailed information.

#25 
